### PR TITLE
[bug] Format date values with expected format

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -34,6 +34,7 @@ export default function Playground() {
     const handleChange = (value, e) => {
         setValue(value);
         console.log(e);
+        console.log("value", value);
     };
     return (
         <div className="px-4 py-8">

--- a/src/components/Calendar/index.tsx
+++ b/src/components/Calendar/index.tsx
@@ -121,8 +121,8 @@ const Calendar: React.FC<Props> = ({
                 const ipt = input?.current;
                 changeDatepickerValue(
                     {
-                        startDate: start,
-                        endDate: end
+                        startDate: dayjs(start).format("YYYY-MM-DD"),
+                        endDate: dayjs(end).format("YYYY-MM-DD")
                     },
                     ipt
                 );


### PR DESCRIPTION
### Description

Date values are displayed in ISO 8601 format (YYYY-MM-DD) but value returned can be formatted differently for single digit days or months.

For example, if you have a date field with a value of 2023-01-09, the value returned will be 2023-1-9.

Because whole numbers are passed into arguments of the function `clickDay` and then concatenated into a string, the leading zeros are dropped. 

This PR adds passes the final values into the dayjs formatter to ensure that the date is formatted correctly.
